### PR TITLE
Remove install instructions for polyglot-release dependencies from the documentation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@ If you're making a major release, there are special considerations, and you shou
 
 Before making a release, make sure you have these tools installed:
  * Git - version > 2.25 
- * [polyglot-release](https://github.com/cucumber/polyglot-release)
+ * [polyglot-release](https://github.com/cucumber/polyglot-release) and its dependencies
  * [changelog](https://github.com/cucumber/changelog/)
 
 ## Upgrade dependencies

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,6 @@ Before making a release, make sure you have these tools installed:
  * Git - version > 2.25 
  * [polyglot-release](https://github.com/cucumber/polyglot-release)
  * [changelog](https://github.com/cucumber/changelog/)
- * The `realpath` command. On MacOS you can install this with `brew install coreutils`
 
 ## Upgrade dependencies
 


### PR DESCRIPTION
### 🤔 What's changed?

Removed perishable information from the documentation. This prevents the documentation from going out of date when `polyglot-release` changes. The dependencies needed by `polyglot-release` are not documented with https://github.com/cucumber/polyglot-release/pull/85

Fixes: https://github.com/cucumber/.github/issues/16