### PR TITLE
Remove upgrade step from the release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,31 +18,6 @@ Before making a release, make sure you have these tools installed:
  * [changelog](https://github.com/cucumber/changelog/)
  * The `realpath` command. On MacOS you can install this with `brew install coreutils`
 
-## Upgrade dependencies
-
-Although we lean on Renovate to do automatic dependency upgrades, it doesn't take care of everything. Before making a release, do a manual check for any dependency upgrades needed, and take the time to upgrade everything that you can.
-
-For JavaScript projects:
-
-    npx npm-check-updates --upgrade
-
-For Ruby projects:
-
-    curl https://raw.githubusercontent.com/cucumber/.github/main/scripts/update-gemspec | bash
-    # If the repo has its own scripts/update-gemspec - delete it!
-
-For Java projects:
-
-    mvn versions:force-releases
-    mvn versions:update-properties -DallowMajorUpdates=true -Dmaven.version.rules="file://`pwd`/.versions/rules.xml"
-
-For Go projects:
-
-    rm go.sum
-    go get -t -u ./...
-
-Make a pull request with any dependency upgrades so that you get a full CI run. If it passes, merge the PR and you can continue with the release.
-
 ## Prepare the release
 
 Anyone with permission to push to the `main` branch can prepare a release.


### PR DESCRIPTION
### 🤔 What's changed?

Updating dependencies is an just before you release is asking for problems. Making a release is -assuming the process works- an activity wich needs a fixed amount of time. Updating depencies is an unbounded time activity.

Additionally Renovate seems to be powerful enough to pickup all upgrades. If some upgrades are not picked up, we should investigate renovate rather then rely on a manual process.

Fixes: https://github.com/cucumber/.github/issues/8
