### PR TITLE
Add workflow to retire inactive contributors

### DIFF
--- a/.github/workflows/retire-inactive-contributors.yaml
+++ b/.github/workflows/retire-inactive-contributors.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cucumber/action-retire-inactive-contributor@main
+    - uses: cucumber/action-retire-inactive-contributor@abb03386eb48a76864a9399651799d4697fef53a
       with:
         github-orgname: cucumber
         maximum-absence-before-retirement: 1 year

--- a/.github/workflows/retire-inactive-contributors.yaml
+++ b/.github/workflows/retire-inactive-contributors.yaml
@@ -1,0 +1,17 @@
+name: Retire inactive contributors (Dry run)
+on:
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cucumber/action-retire-inactive-contributor@main
+      with:
+        github-orgname: cucumber
+        maximum-absence-before-retirement: 1 year
+        alumni-team: alumni
+        dry-run: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.RETIRE_INACTIVE_CONTRIBUTORS_TOKEN }} 


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Adding a workflow to retire inactive contributors

### ⚡️ What's your motivation? 

For security reasons, we want to retire contributors who haven't been active recently into an alumni team with no permissions.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
