### PR TITLE
PULL_REQUEST_TEMPLATE: fix link to CHANGELOG

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,7 @@ Feel free to delete any tasks that are not relevant, or add new ones.
 - [ ] My change requires a change to the documentation.
   - [ ] I have updated the documentation accordingly.
 - [ ] Users should know about my change
-  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
+  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
 
 ----
 


### PR DESCRIPTION


### 🤔 What's changed?

This changes the CHANGELOG.md link to work correctly.


### ⚡️ What's your motivation? 

The link led to a 404 not found.

The PR and the regular code viewing Markdown links are rendered differently. This kind of link would have worked in a README.md or anything in the repo, but not in a PR or Issue.


### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

