### PR TITLE
Profile README.md: refer to example in cucumber-ruby

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,7 +9,7 @@
 
 Cucumber is a tool for running automated acceptance tests, written in plain language. Because they're written in plain language, they can be read by anyone on your team. Because they can be read by anyone, they help improve communication, collaboration and trust on your team. 💖
 
-![Gherkin example](https://github.com/cucumber/cucumber-ruby/raw/main/.github/img/gherkin-example.png)
+![Gherkin example](https://github.com/cucumber/cucumber-ruby/raw/main/docs/img/gherkin-example.png)
 
 Cucumber was built to support [Behaviour-Driven Development](https://cucumber.io/docs/bdd/) (BDD).
 


### PR DESCRIPTION


### 🤔 What's changed?

An image path got pointed right. It used to point to this repo, but the file resides elsewhere.

I used the same path as the fixed logo from #32.

### ⚡️ What's your motivation? 

This fixes #33
 

### 🏷️ What kind of change is this?



- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
