### PR TITLE
chore: add github sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 open_collective: cucumber
+github: cucumber


### PR DESCRIPTION
This PR adds the entry to the org-wide `FUNDING.yml` which should mean we display a GitHub sponsors button on all repos.

(Note if any repos have their own `FUNDING.yml` it should be removed so it can inherit this one!)
