### PR TITLE
chore: update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Please do not report security vulnerabilities through public issues, discussions
 
 ## Response
 
-Vulnerabilities will be disclosed initially to our enterprise partners Tidelift, and will subsequently be publicly disclosed once a patch is available.
+Vulnerabilities will be disclosed initially to our enterprise partners through Tidelift, and will subsequently be publicly disclosed once a patch is available.
 
 Unless otherwise specified in the `SECURITY.md` in the individual repository, security patches will be released against the most recent version only. This applies to both vulnerabilities in the repository itself, and transitive dependency issues that are resolved by upgrading or removing.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,22 @@
 # Security Policy
 
-## Supported Versions
+The Cucumber team takes security very seriously and appreciates (and will endeavour to recognise publicly) people who responsibly disclose vulnerabilities.
 
-Unless otherwise specified in the `SECURITY.md` in the project repository
-only the most recent release is supported.
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+If you believe you have found a security vulnerability in any Cucumber-owned repository, please report it to us through coordinated disclosure.
 
-To report a security vulnerability, please email team@cucumber.community.
+Please do not report security vulnerabilities through public issues, discussions, or pull requests. Instead, please send an email to <team@cucumber.community>. Try to include as much detail as you can, including:
+
+- The broad category of issue
+- An unambiguous link to the vulnerable code - i.e. the file(s), but also git commit/tag/branch
+- Configuration and other instructions required to reproduce the issue
+- Proof of concept code we can run (if possible)
+- Summary of the issue's potential impact
+
+## Response
+
+Vulnerabilities will be disclosed initially to our enterprise partners Tidelift, and will subsequently be publicly disclosed once a patch is available.
+
+Unless otherwise specified in the `SECURITY.md` in the individual repository, security patches will be released against the most recent version only. This applies to both vulnerabilities in the repository itself, and transitive dependency issues that are resolved by upgrading or removing.
+


### PR DESCRIPTION
Update and expand the security policy to:

- Outline our response steps, including early disclosure to Tidelift (one of their requirements)
- Give more detail about disclosure process and expectations