### PR TITLE
Remove emoji from header

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ Cucumber is open source, built and maintained by people just like you! All of th
 
 Everyone interacting in these codebases and issue trackers is expected to follow the [Cucumber Community Code of Conduct](https://cucumber.io/conduct).
 
-### Get in touch 🙋‍♀️
+### Get in touch
 
 If you have questions about using Cucumber, or ideas for how we could improve it, head over to our [GitHub Discussions](https://github.com/orgs/cucumber/discussions) forum. If you want chat with the maintainers, the best place for that is to join the [Community Slack](https://cucumber.io/community#slack)
 


### PR DESCRIPTION
Github automatically converts headers in Markdown to HTML links.

Unfortunately this includes any emoji included in the header. So 

```
### Get in touch 🙋‍♀️
```

is linked to as `https://github.com/cucumber#get-in-touch-%EF%B8%8F` which is hard to parse and easy to break should the the emoji change.

Removing the emoji will make https://github.com/cucumber/common/issues/2195 a bit easier, but also remove some color.