### PR TITLE
Use mods@cucumber.io

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,9 +59,8 @@ The current moderators of the Cucumber community are:
 
 - Matt Wynne
 - David Goss
-- Volodymyr Bober
 
-You can contact us by email at [mods@cucumber.community](mailto:mods@cucumber.community).
+You can contact us by email at [mods@cucumber.io](mailto:mods@cucumber.io).
 
 ## References / inspiration
 


### PR DESCRIPTION

### 🤔 What's changed?

With the emancipation from Smartbear complete, we can now use mods@cucumber.io.
